### PR TITLE
Added Parameterized Trigger Plugin Support

### DIFF
--- a/src/main/java/com/sonyericsson/rebuild/RebuildAction.java
+++ b/src/main/java/com/sonyericsson/rebuild/RebuildAction.java
@@ -24,11 +24,9 @@
 package com.sonyericsson.rebuild;
 
 import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
 import hudson.model.Action;
 import hudson.model.BooleanParameterValue;
 import hudson.model.Cause;
-import hudson.model.Cause.UpstreamCause;
 import hudson.model.CauseAction;
 import hudson.model.FileParameterValue;
 import hudson.model.Hudson;


### PR DESCRIPTION
This change will clone the existing parameters of the build rather than using the parameter definitions from the project.  This causes it to function better when used with the Parameterized Trigger Plugin, which allows for the parameter definitions to be defined on upstream builds.

Initially I thought about walking the build cause chain and attempting to find the appropriate parameter definitions, but if you rebuild a build twice in a row, then the build you're rebuilding has only a UserCause which doesn't provide a way of fetching the parameter definitions.
