### PR TITLE
Not allow to build matrix configuration alone

### DIFF
--- a/src/main/java/com/sonyericsson/rebuild/RebuildActionFactory.java
+++ b/src/main/java/com/sonyericsson/rebuild/RebuildActionFactory.java
@@ -23,6 +23,7 @@
  */
 package com.sonyericsson.rebuild;
 
+import hudson.matrix.MatrixConfiguration;
 import hudson.Extension;
 import hudson.model.*;
 
@@ -39,6 +40,8 @@ public class RebuildActionFactory extends TransientBuildActionFactory {
 
     @Override
     public Collection<? extends Action> createFor(Run target) {
+        if(target.getParent() instanceof MatrixConfiguration)
+            return emptyList();
         AbstractBuild build = (AbstractBuild) target;
         boolean hasRebuildAction = target.getAction(RebuildAction.class) != null;
         if (hasRebuildAction) {

--- a/src/main/java/com/sonyericsson/rebuild/RebuildProjectActionFactory.java
+++ b/src/main/java/com/sonyericsson/rebuild/RebuildProjectActionFactory.java
@@ -23,6 +23,7 @@
  */
 package com.sonyericsson.rebuild;
 
+import hudson.matrix.MatrixConfiguration;
 import hudson.Extension;
 import hudson.model.AbstractProject;
 import hudson.model.Action;
@@ -30,7 +31,9 @@ import hudson.model.TransientProjectActionFactory;
 
 import java.util.Collection;
 
+import java.util.Collections;
 import static java.util.Collections.singleton;
+import static java.util.Collections.emptyList;
 
 /**
  * Makes the rebuild button available on the project level.
@@ -41,6 +44,8 @@ public class RebuildProjectActionFactory extends TransientProjectActionFactory {
 
     @Override
     public Collection<? extends Action> createFor(AbstractProject abstractProject) {
+        if(abstractProject instanceof MatrixConfiguration)
+            return emptyList();
         return singleton(new RebuildLastCompletedBuildAction());
     }
 }


### PR DESCRIPTION
Rebuilding of matrix configuration can cause problems.
Matrix project can be build if configuration is in queue (and concurrent builds is not allowed).  If it happens it causes that matrix build fails with stack trace (item in queue miss ParentBuildAction):

java.lang.NullPointerException
    at hudson.matrix.MatrixBuild$MatrixBuildExecution.doRun(MatrixBuild.java:356)
    at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:499)
    at hudson.model.Run.execute(Run.java:1502)
    at hudson.matrix.MatrixBuild.run(MatrixBuild.java:289)
    at hudson.model.ResourceController.execute(ResourceController.java:88)
    at hudson.model.Executor.run(Executor.java:236)
    at hudson.model.OneOffExecutor.run(OneOffExecutor.java:66)

I think that it is better not to allow rebuild matrix configuration (in Jenkins core is not able to built matrix configuration alone -without matrix build)
