### PR TITLE
Hack to support Extended Choice Parameter Plugin

### DIFF
--- a/src/main/resources/com/sonyericsson/rebuild/RebuildAction/ExtendedChoiceParameterValue.jelly
+++ b/src/main/resources/com/sonyericsson/rebuild/RebuildAction/ExtendedChoiceParameterValue.jelly
@@ -1,0 +1,38 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Tom Huybrechts
+
+Copyright 2010 Sony Ericsson Mobile Communications.All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
+	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
+	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
+    <f:entry title="${it.name}" description="${it.description}">
+        <div name="parameter" description="${it.description}">
+            <input type="hidden" name="name" value="${it.name}" />
+            <f:textbox name="value" value="${it.value}" />
+        </div>
+    </f:entry>
+</j:jelly>
+
+


### PR DESCRIPTION
This commit repurposes StringParameterValue.jelly to support ExtendedChoiceParameter.

While the duplication is less than ideal, it addresses a common complaint, as evidenced in the comments at https://wiki.jenkins-ci.org/display/JENKINS/Extended+Choice+Parameter+plugin.
