### PR TITLE
Improved appearance of the RebuildCause

### DIFF
--- a/src/main/java/com/sonyericsson/rebuild/RebuildCause.java
+++ b/src/main/java/com/sonyericsson/rebuild/RebuildCause.java
@@ -1,7 +1,7 @@
 /*
  *  The MIT License
  *
- *  Copyright 2013 Joel Johnson and contributors.
+ *  Copyright 2013 Joel Johnson, Oleg Nenashev and contributors.
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +23,10 @@
  */
 package com.sonyericsson.rebuild;
 
+import hudson.console.ModelHyperlinkNote;
 import hudson.model.Cause;
 import hudson.model.Run;
+import hudson.model.TaskListener;
 
 /**
  * A cause specifying that the build was a rebuild of another build. Extends
@@ -32,10 +34,37 @@ import hudson.model.Run;
  * builds is inherited (linking, etc).
  *
  * @author Joel Johnson
+ * @author Oleg Nenashev
  */
 public class RebuildCause extends Cause.UpstreamCause {
 
     public RebuildCause(Run<?, ?> up) {
         super(up);
+    }
+
+    @Override
+    public String getShortDescription() {
+        return Messages.Cause_RebuildCause_ShortDescription(getUpstreamBuild());
+    }
+    
+    public String getShortDescritptionHTML() {
+        return Messages.Cause_RebuildCause_ShortDescriptionHTML(getUpstreamBuild(), '/' + getUpstreamUrl() + getUpstreamBuild());
+    }
+
+    private void indent(TaskListener listener, int depth) {
+            for (int i = 0; i < depth; i++) {
+                listener.getLogger().print(' ');
+            }
+        }
+
+    @Override
+    public void print(TaskListener listener) {
+        print (listener, 0);
+    }
+      
+    private void print(TaskListener listener, int depth) {
+        indent(listener, depth);
+        listener.getLogger().println(Messages.Cause_RebuildCause_ShortDescription(
+               ModelHyperlinkNote.encodeTo('/' + getUpstreamUrl() + getUpstreamBuild(), Integer.toString(getUpstreamBuild()))));
     }
 }

--- a/src/main/resources/com/sonyericsson/rebuild/Messages.properties
+++ b/src/main/resources/com/sonyericsson/rebuild/Messages.properties
@@ -24,3 +24,5 @@
 
 
 AbstractProject.Pronoun=Project
+Cause.RebuildCause.ShortDescription=Rebuilds build #{0}
+Cause.RebuildCause.ShortDescriptionHTML=Rebuilds build <a href="{1}">#{0}<a/>

--- a/src/main/resources/com/sonyericsson/rebuild/RebuildCause/description.jelly
+++ b/src/main/resources/com/sonyericsson/rebuild/RebuildCause/description.jelly
@@ -1,0 +1,32 @@
+<!--
+The MIT License
+
+Copyright (c) 2013, Sun Microsystems, Inc., Alan Harder, Oleg Nenashev and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <!-- upstreamUrl added in 1.284, so handle missing value; also JENKINS-14816 (job/build may have been deleted) -->
+    <span><j:out value='${it.upstreamUrl!=null and
+                            app.getItemByFullName(it.upstreamProject)!=null and
+                            app.getItemByFullName(it.upstreamProject).getBuildByNumber(it.upstreamBuild)!=null ?
+                            it.shortDescritptionHTML : it.shortDescription}'/>
+    </span>
+</j:jelly>


### PR DESCRIPTION
RebuildCause info prints its own info instead of UpstreamCause's output
Improves #7

Signed-off-by: Oleg Nenashev nenashev@synopsys.com
