### PR TITLE
Provides an interface for other plugins to support rebuild plugin.

### DIFF
--- a/src/main/java/com/sonyericsson/rebuild/RebuildAction.java
+++ b/src/main/java/com/sonyericsson/rebuild/RebuildAction.java
@@ -445,4 +445,23 @@ public class RebuildAction implements Action {
         }
         return actions;
     }
+    
+    /**
+     * @param value the parameter value to show to rebuild.
+     * @return page for the parameter value.
+     */
+    public RebuildParameterPage getRebuildParameterPage(ParameterValue value) {
+        RebuildParameterPage page = null;
+        if (value instanceof RebuildableParameterValue) {
+            // If that parameter value provides its own view, use it.
+            page =  ((RebuildableParameterValue)value).getRebuildPage();
+        } else {
+            // If that parameter value does not provide its own view,
+            // use the one provided by me.
+            page = new RebuildParameterPage();
+            page.setClazz(getClass());
+            page.setPage(String.format("%s.jelly", value.getClass().getSimpleName()));
+        }
+        return page;
+    }
 }

--- a/src/main/java/com/sonyericsson/rebuild/RebuildParameterPage.java
+++ b/src/main/java/com/sonyericsson/rebuild/RebuildParameterPage.java
@@ -1,0 +1,58 @@
+/*
+ * The MIT License
+ * 
+ * Copyright (c) 2013 IKEDA Yasuyuki
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.sonyericsson.rebuild;
+
+/**
+ * A bean contains information of the view to show parameters in rebuild page.
+ */
+public class RebuildParameterPage {
+    private Class<?> clazz = null;
+    /**
+     * @return the class for the view.
+     */
+    public Class<?>  getClazz() {
+        return clazz;
+    }
+    /**
+     * @param clazz the class for the view. 
+     */
+    public void setClazz(Class<?>  clazz) {
+        this.clazz = clazz;
+    }
+    
+    private String page = null;
+    /**
+     * @return the path of jelly(or groovy) file.
+     */
+    public String getPage() {
+        return page;
+    }
+    /**
+     * @param page the path of jelly(or groovy) file.
+     */
+    public void setPage(String page) {
+        this.page = page;
+    }
+}

--- a/src/main/java/com/sonyericsson/rebuild/RebuildableParameterValue.java
+++ b/src/main/java/com/sonyericsson/rebuild/RebuildableParameterValue.java
@@ -1,0 +1,37 @@
+/*
+ * The MIT License
+ * 
+ * Copyright (c) 2013 IKEDA Yasuyuki
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.sonyericsson.rebuild;
+
+/**
+ * Indicates supports rebuild-plugin.
+ */
+public interface RebuildableParameterValue {
+    /**
+     * Specify the view to use.
+     * 
+     * @return the view for this parameter used when rebuilding.
+     */
+    public RebuildParameterPage getRebuildPage();
+}

--- a/src/main/resources/com/sonyericsson/rebuild/RebuildAction/parameterized.jelly
+++ b/src/main/resources/com/sonyericsson/rebuild/RebuildAction/parameterized.jelly
@@ -51,9 +51,11 @@ THE SOFTWARE.
             <j:set var="paramAction" value="${build.getAction(parmactionClass)}" />
             <f:form method="post" action="configSubmit" name="config">
                 <j:forEach var="parameterValue" items="${paramAction.parameters}">
-                    <j:set var="valuePage" value="${parameterValue.class.simpleName}" />
+                    <j:scope>
+                    <j:set var="page" value="${it.getRebuildParameterPage(parameterValue)}" />
                     <st:include it="${parameterValue}"
-                                from="${it}"  page="${valuePage}.jelly" />
+                                class="${page.clazz}"  page="${page.page}" />
+                    </j:scope>
                 </j:forEach>
                 <br/>
                 <br/>

--- a/src/test/resources/com/sonyericsson/rebuild/RebuildValidatorTest/SupportedUnknownParameterValue/rebuild.groovy
+++ b/src/test/resources/com/sonyericsson/rebuild/RebuildValidatorTest/SupportedUnknownParameterValue/rebuild.groovy
@@ -1,0 +1,16 @@
+package com.sonyericsson.rebuild.RebuildValidatorTest.SupportedUnknownParameterValue;
+
+f = namespace("lib/form")
+
+// "it" will be overridden inside nexted tags.
+String itName = it.name
+String itValue = it.value
+
+f.entry(title: it.name, description: it.description) {
+    div(name: "parameter") {
+        input(type: "hidden", name: "name", value: itName)
+        input(type: "text", name: "value", value: itValue)
+        text("This is a mark for test")
+    }
+}
+


### PR DESCRIPTION
When a new plugin with its own parameter value comes, we need to add a new jelly file for that plugin to rebuild plugin (as in bf501fb).
This means rebuild plugin must know all Jenkins plugins, which is not realistic.

This pull request add a feature for other plugins to support rebuild plugin.
If a plugin with its own parameter wants to work with rebuild plugin, it does as followings:
- Have its parameter value class to implement `RebuildableParameterValue`.
- Define `getRebuildPage()`, which returns a hint to access a jelly file for that parameter value.

If the parameter value class does not support `RebuildableParameterValue`, rebuild plugin works as now. 
