### PR TITLE
[JENKINS-19910] added support for maven metadata plugin

### DIFF
--- a/src/main/resources/com/sonyericsson/rebuild/RebuildAction/MavenMetadataParameterValue.jelly
+++ b/src/main/resources/com/sonyericsson/rebuild/RebuildAction/MavenMetadataParameterValue.jelly
@@ -1,0 +1,75 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Tom Huybrechts
+
+Copyright 2010 Sony Ericsson Mobile Communications.All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
+         xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
+         xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
+    <j:invoke var="buildClass" on="${currentThread.contextClassLoader}" method="loadClass">
+        <j:arg value="hudson.model.AbstractBuild" />
+    </j:invoke>
+    <j:invoke var="paramDefPro" on="${currentThread.contextClassLoader}" method="loadClass">
+        <j:arg value="hudson.model.ParametersDefinitionProperty" />
+    </j:invoke>
+    <j:set var="build" value="${request.findAncestorObject(buildClass)}" />
+    <j:set var="pdp" value="${build.getProject().getProperty(paramDefPro)}" />
+    <j:set var="pname" value="${it.name}" />
+    <j:set var="pd" value="${pdp.getParameterDefinition(pname)}" />
+    <f:entry title="${it.name}" description="${it.description}">
+        <div name="parameter" description="${it.description}">
+            <input type="hidden" name="name" value="${it.name}"/>
+            <input type="hidden" name="groupId" value="${pd.groupId}"/>
+            <input type="hidden" name="artifactId" value="${pd.artifactId}"/>
+            <input type="hidden" name="packaging" value="${pd.packaging}"/>
+            <j:choose>
+                <j:when test="${pd.versions.size() == null or pd.versions.size() == 0}">
+                    <!-- no tags at all -->
+                    ${%No versions found.}<br/>
+                    ${%If you trigger the build, it will likely fail.}
+                </j:when>
+                <j:when test='${pd.versions.size() == 1 and pd.versions.get(0).startsWith("&amp;lt;") and pd.versions.get(0).endsWith("&amp;gt;")}'>
+                    <!-- tags could not be retrieved -->
+                    <div style="color: #CC0000; font-weight: bold;">
+                        <!-- we remove the lowerThan and greaterThan signs from the message -->
+                        ${pd.versions.get(0).substring(4, pd.versions.get(0).length()-4)}<br/>
+                        ${%If you trigger the build, it will likely fail.}
+                    </div>
+                </j:when>
+                <j:otherwise>
+                    <!-- everything is fine, we can display the drop-down list to the user -->
+                    <select name="version">
+                        <j:forEach var="version" items="${pd.versions}">
+                            <f:option selected="${version == it.version}">
+                                ${version}
+                            </f:option>
+                        </j:forEach>
+                    </select>
+                </j:otherwise>
+            </j:choose>
+        </div>
+    </f:entry>
+</j:jelly>
+
+


### PR DESCRIPTION
This pull request adds support for rebuilding projects which uses the maven metadata plugin parameter.

The form includes the same error handling as the original form used by the maven metadata plugin.
