### PR TITLE
Defaulting to a StringParameterValue

### DIFF
--- a/src/main/resources/com/sonyericsson/rebuild/RebuildAction/parameterized.jelly
+++ b/src/main/resources/com/sonyericsson/rebuild/RebuildAction/parameterized.jelly
@@ -52,8 +52,12 @@ THE SOFTWARE.
             <f:form method="post" action="configSubmit" name="config">
                 <j:forEach var="parameterValue" items="${paramAction.parameters}">
                     <j:set var="valuePage" value="${parameterValue.class.simpleName}" />
+                    <j:new className="java.lang.File" var="p_file">
+                        <j:arg type="java.lang.String" value="${valuePage}.jelly"/>
+                    </j:new>
+                    <j:setif var="valuePage" test="${p_file.exists()}" false="StringParameterValue"/>
                     <st:include it="${parameterValue}"
-                                from="${it}"  page="${valuePage}.jelly" />
+                                from="${it}"  page="${valuePage}.jelly"/>
                 </j:forEach>
                 <br/>
                 <br/>

--- a/src/main/resources/com/sonyericsson/rebuild/RebuildAction/parameterized.jelly
+++ b/src/main/resources/com/sonyericsson/rebuild/RebuildAction/parameterized.jelly
@@ -52,10 +52,12 @@ THE SOFTWARE.
             <f:form method="post" action="configSubmit" name="config">
                 <j:forEach var="parameterValue" items="${paramAction.parameters}">
                     <j:set var="valuePage" value="${parameterValue.class.simpleName}" />
-                    <j:new className="java.lang.File" var="p_file">
+                    <j:new className="java.io.File" var="p_file">
                         <j:arg type="java.lang.String" value="${valuePage}.jelly"/>
                     </j:new>
-                    <j:setif var="valuePage" test="${p_file.exists()}" false="StringParameterValue"/>
+                    <j:if test="${p_file.exists()=='false'}">
+                      <j:set var="valuePage" value="StringParameterValue"/>
+                    </j:if>
                     <st:include it="${parameterValue}"
                                 from="${it}"  page="${valuePage}.jelly"/>
                 </j:forEach>

--- a/src/main/resources/com/sonyericsson/rebuild/RebuildAction/parameterized.jelly
+++ b/src/main/resources/com/sonyericsson/rebuild/RebuildAction/parameterized.jelly
@@ -52,14 +52,14 @@ THE SOFTWARE.
             <f:form method="post" action="configSubmit" name="config">
                 <j:forEach var="parameterValue" items="${paramAction.parameters}">
                     <j:set var="valuePage" value="${parameterValue.class.simpleName}" />
-                    <j:new className="java.io.File" var="p_file">
-                        <j:arg type="java.lang.String" value="${valuePage}.jelly"/>
-                    </j:new>
-                    <j:if test="${p_file.exists()=='false'}">
-                      <j:set var="valuePage" value="StringParameterValue"/>
-                    </j:if>
-                    <st:include it="${parameterValue}"
+                    <j:catch var="ex">
+                      <st:include it="${parameterValue}"
                                 from="${it}"  page="${valuePage}.jelly"/>
+                    </j:catch>
+                    <j:if test="${ex != null and ex.toString().contains('No page found')}">
+                      <st:include it="${parameterValue}"
+                                from="${it}"  page="StringParameterValue.jelly"/>
+                    </j:if>
                 </j:forEach>
                 <br/>
                 <br/>


### PR DESCRIPTION
Currently the rebuild plugin will throw an exception if it encounters a parameter type it doesn't know about - which could be introduced by many other plugins or custom HPI's. 

This can be worked around by copying the StringParameterValue.jelly to one with the name of the new parameter type and restarting Jenkins - somewhat inconvenient, especially where restarting is an option that may need to be scheduled on a busy CI/Test farm.

These changes will cause the RebuildPlugin to use the custom jelly for a ParameterValue type if it exists in the folder, but if there is none, it will fall back to the StringParameterValue rendering, which for all but a few unusual cases, should be good enough. This saves rebuild plugin having to peg new plugins, and saves having to work around and restart for busy installations.

Tested on the current Jenkins LTS version.