### PR TITLE
Fix URL for RebuildCause when Hudson does not sit at the top of the serv...

### DIFF
--- a/src/main/java/com/sonyericsson/rebuild/RebuildCause.java
+++ b/src/main/java/com/sonyericsson/rebuild/RebuildCause.java
@@ -23,6 +23,7 @@
  */
 package com.sonyericsson.rebuild;
 
+import jenkins.model.Jenkins;
 import hudson.console.ModelHyperlinkNote;
 import hudson.model.Cause;
 import hudson.model.Run;
@@ -55,7 +56,7 @@ public class RebuildCause extends Cause.UpstreamCause {
      * @return String description.
      */
     public String getShortDescritptionHTML() {
-        return Messages.Cause_RebuildCause_ShortDescriptionHTML(getUpstreamBuild(), '/'
+        return Messages.Cause_RebuildCause_ShortDescriptionHTML(getUpstreamBuild(), Jenkins.getInstance().getRootUrl() + '/'
                 + getUpstreamUrl() + getUpstreamBuild());
     }
     /**


### PR DESCRIPTION
...er URL

When hudson is placed un a sub dir of the web server (ie http://server/hudson), link to project used for rebuild is broken.
Use getRootUrl to fix this

Signed-off-by: Nicolas Morey-Chaisemartin nmorey@kalray.eu
