### PR TITLE
Update RebuildLastCompletedBuildAction.java

### DIFF
--- a/src/main/java/com/sonyericsson/rebuild/RebuildLastCompletedBuildAction.java
+++ b/src/main/java/com/sonyericsson/rebuild/RebuildLastCompletedBuildAction.java
@@ -53,6 +53,6 @@ public class RebuildLastCompletedBuildAction extends RebuildAction {
 
     @Override
     public String getDisplayName() {
-        return "Rebuild Last";
+        return "Rebuild Last Completed";
     }
 }


### PR DESCRIPTION
Our users thinks that pressing "Rebuild Last" will rebuild the last build even if it was aborted. Changing the text to "Rebuild Last Completed" might help with that.
