### PR TITLE
Fixed link to the build for instances installed not as ROOT app

### DIFF
--- a/src/main/java/com/sonyericsson/rebuild/RebuildCause.java
+++ b/src/main/java/com/sonyericsson/rebuild/RebuildCause.java
@@ -36,6 +36,9 @@ import hudson.model.TaskListener;
  * @author Joel Johnson
  * @author Oleg Nenashev
  */
+
+import jenkins.model.Jenkins;
+
 public class RebuildCause extends Cause.UpstreamCause {
     /**
      * RebuildCause constructor.
@@ -55,8 +58,8 @@ public class RebuildCause extends Cause.UpstreamCause {
      * @return String description.
      */
     public String getShortDescritptionHTML() {
-        return Messages.Cause_RebuildCause_ShortDescriptionHTML(getUpstreamBuild(), '/'
-                + getUpstreamUrl() + getUpstreamBuild());
+        return Messages.Cause_RebuildCause_ShortDescriptionHTML(getUpstreamBuild(),
+                Jenkins.getInstance().getRootUrlFromRequest() + getUpstreamUrl() + getUpstreamBuild());
     }
     /**
      * Method calculate the indent.


### PR DESCRIPTION
If Jenkins installed as additional application and not as ROOT application (i.e. http://host:port/jenkins/ and not http://host:port/), the link on a job's build page that points to the build which this particular build rebuilds is incorrect, it points to server's ROOT application instead of additional one. So it works great if Jenkins is installed in root, but isn't if it is an additional application.

![ik3test2__11__jenkins_](https://cloud.githubusercontent.com/assets/6283436/4345141/b814ce80-40b8-11e4-83a1-13f016e1f57e.png)
