### PR TITLE
Do not remember passwords by default

### DIFF
--- a/src/main/resources/com/sonyericsson/rebuild/RebuildDescriptor/config.jelly
+++ b/src/main/resources/com/sonyericsson/rebuild/RebuildDescriptor/config.jelly
@@ -5,7 +5,7 @@
         <f:entry title="Rebuild Configuration">
                 <table width="100%">
                     <f:entry title="Remember Password Enabled" field="rememberPasswordEnabled">
-                        <f:checkbox default="true" checked="${descriptor.rebuildConfiguration.rememberPasswordEnabled}" />
+                        <f:checkbox checked="${descriptor.rebuildConfiguration.rememberPasswordEnabled}" />
                     </f:entry>
                 </table>
         </f:entry>


### PR DESCRIPTION
I think that most users of this plugin would be surprised to learn that Jenkins was storing their passwords on disk by default. This setting should be disabled by default to reduce the risk of passwords being compromised or inadvertently shared because they are stored on a Jenkins machine.

This reverts commit 690ac040b745e95de347e429d9ed23c2312374b5.