### PR TITLE
[JENKINS-26024] Display a more informative error message

### DIFF
--- a/src/main/java/com/sonyericsson/rebuild/RebuildValidator.java
+++ b/src/main/java/com/sonyericsson/rebuild/RebuildValidator.java
@@ -47,7 +47,7 @@ public abstract class RebuildValidator implements Serializable, ExtensionPoint {
         if (Util.isOverridden(RebuildValidator.class, getClass(), "isApplicable", AbstractBuild.class) && build instanceof AbstractBuild) {
             return isApplicable((AbstractBuild) build);
         } else {
-            throw new AbstractMethodError("you must override the new overload of isApplicable");
+            throw new AbstractMethodError("you must override the new overload of isApplicable in " + getClass().getName());
         }
     }
 


### PR DESCRIPTION
Amends #31 to indicate which subclass needs to be updated. I found the following stack trace in a log file:

```
java.lang.AbstractMethodError: you must override the new overload of isApplicable
        at com.sonyericsson.rebuild.RebuildValidator.isApplicable(RebuildValidator.java:50)
        at com.sonyericsson.rebuild.RebuildActionFactory.createFor(RebuildActionFactory.java:61)
        at hudson.model.Run.getTransientActions(Run.java:373)
```

but the installation does not seem to include `gerrit-trigger`, which is the only public implementor I can find (and which is fixed as of https://github.com/jenkinsci/gerrit-trigger-plugin/pull/240).

@reviewbybees
