### PR TITLE
Build with empty ParametersAction & copying of all build actions

### DIFF
--- a/src/main/java/com/sonyericsson/rebuild/RebuildAction.java
+++ b/src/main/java/com/sonyericsson/rebuild/RebuildAction.java
@@ -254,6 +254,7 @@ public class RebuildAction implements Action {
         getProject().checkPermission(Item.BUILD);
 
         List<Action> actions = constructRebuildCause(build, null);
+        fillOtherBuildActions(currentBuild, actions);
         Hudson.getInstance().getQueue().schedule((Queue.Task) currentBuild.getParent(), 0, actions);
         response.sendRedirect("../../");
     }
@@ -298,6 +299,7 @@ public class RebuildAction implements Action {
             }
 
             List<Action> actions = constructRebuildCause(build, new ParametersAction(values));
+            fillOtherBuildActions(build, actions);
             Hudson.getInstance().getQueue().schedule((Queue.Task) build.getParent(), 0, actions);
 
             rsp.sendRedirect("../../");
@@ -486,5 +488,19 @@ public class RebuildAction implements Action {
         // Else we return that we haven't found anything.
         // So Jelly fallback could occur.
         return null;
+    }
+
+    /**
+     * Method for copying of old build parameters (such as git revision from git plugin)
+     *
+     * @param build old build for parameters extraction
+     * @param actions list for filling
+     */
+    private void fillOtherBuildActions(Run build, List<Action> actions) {
+        for (Action a: build.getActions()) {
+            if (!(a instanceof CauseAction) && !(a instanceof ParametersAction)) {
+                actions.add(a);
+            }
+        }
     }
 }

--- a/src/main/java/com/sonyericsson/rebuild/RebuildAction.java
+++ b/src/main/java/com/sonyericsson/rebuild/RebuildAction.java
@@ -204,7 +204,7 @@ public class RebuildAction implements Action {
         Run currentBuild = request.findAncestorObject(Run.class);
         if (currentBuild != null) {
             ParametersAction paramAction = currentBuild.getAction(ParametersAction.class);
-            if (paramAction != null) {
+            if (paramAction != null && paramAction.getParameters().size() > 0) {
                 RebuildSettings settings = (RebuildSettings)getProject().getProperty(RebuildSettings.class);
                 if (settings != null && settings.getAutoRebuild()) {
                     parameterizedRebuild(currentBuild, response);

--- a/src/test/java/com/sonyericsson/rebuild/RebuildValidatorTest.java
+++ b/src/test/java/com/sonyericsson/rebuild/RebuildValidatorTest.java
@@ -394,6 +394,27 @@ public class RebuildValidatorTest extends HudsonTestCase {
 	}
 
 	/**
+	 * Treats build as non-parameterized if it has empty ParametersAction
+	 *
+	 * @throws Exception
+	 *             Exception
+	 */
+	public void testStartRebuildWithEmptyParametersAction()
+			throws Exception {
+		FreeStyleProject project = createFreeStyleProject();
+
+		project.scheduleBuild2(0, new Cause.UserIdCause(),
+				new ParametersAction())
+				.get();
+		HtmlPage page = createWebClient().getPage(project,
+				"1");
+		page.getAnchorByText("Rebuild").click();
+
+		assertEquals(2, project.getBuilds().size());
+		assertBuildStatusSuccess(project.getLastBuild());
+	}
+
+	/**
 	 * A parameter value rebuild plugin does not know.
 	 */
 	public static class UnsupportedUnknownParameterValue extends

--- a/src/test/java/com/sonyericsson/rebuild/RebuildValidatorTest.java
+++ b/src/test/java/com/sonyericsson/rebuild/RebuildValidatorTest.java
@@ -47,6 +47,7 @@ import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
@@ -415,6 +416,34 @@ public class RebuildValidatorTest extends HudsonTestCase {
 	}
 
 	/**
+	 * Creates a new freestyle project and build with an non-parameter action.
+	 * Verify that rebuild has a copy of this action.
+	 *
+	 * @throws Exception
+	 *             Exception
+	 */
+	public void testCopyingUnknownActionToNewBuild() throws Exception {
+		FreeStyleProject project = createFreeStyleProject();
+
+		Action action = new SupportedUnknownAction();
+		Build build = project.scheduleBuild2(0, new Cause.RemoteCause("host", "note"), action).get();
+
+		while (project.isBuilding()) {
+			Thread.sleep(DELAY);
+		}
+
+		HtmlPage page = createWebClient().getPage(build);
+		page.getAnchorByText("Rebuild").click();
+
+		assertEquals(2, project.getBuilds().size());
+		assertBuildStatusSuccess(project.getLastBuild());
+
+		SupportedUnknownAction rebuildAction =
+				project.getLastBuild().getAction(SupportedUnknownAction.class);
+		assertNotNull(rebuildAction);
+	}
+
+	/**
 	 * A parameter value rebuild plugin does not know.
 	 */
 	public static class UnsupportedUnknownParameterValue extends
@@ -499,6 +528,14 @@ public class RebuildValidatorTest extends HudsonTestCase {
 			}
 		}
 
+	}
+
+	public static class SupportedUnknownAction implements Action {
+		private static final long serialVersionUID = 1014662680565914673L;
+
+		public String getUrlName() { return "/example"; }
+		public String getDisplayName() { return "unknown action"; }
+		public String getIconFileName() { return "icon.png"; }
 	}
 
 	/**


### PR DESCRIPTION
Hello everyone. I have such problem with jenkins: I've set up jenkins not-paramererized project to build stash repository. For every new commit stash sends notification to jenkins (url git/notifyCommit which belongs to git plugin). Sometimes build fails and I want to rebuild it with rebuild-plugin. I want to rebuild particular commit, not the last one, but when I click "Rebuild" button jenkins rebuilds last commit. I looked through the code of rebuild-plugin and git-plugin and found that rebuild-plugin copies only ParametersAction-s properties of build and git-plugin stores information about git commit in RevisionParameterAction which is not successor of ParametersAction. That is why jenkins rebuilds wrong commit. I've created fix for rebuild-plugin but I'm not sure that it is right solution. Should I fix git-plugin instead? I mean make RevisionParameterAction a successor of ParametersAction or make a checkbox "add revistion as a build parameter"? Or may be I need new plugin? What do you think which solution will be correct?