### PR TITLE
JENKINS-38635: Correct NodeParameterValue.jelly

### DIFF
--- a/src/main/resources/com/sonyericsson/rebuild/RebuildAction/NodeParameterValue.jelly
+++ b/src/main/resources/com/sonyericsson/rebuild/RebuildAction/NodeParameterValue.jelly
@@ -4,7 +4,7 @@
     <f:entry title="${it.name}" description="${it.description}">
         <div name="parameter" description="${it.description}">
             <input type="hidden" name="name" value="${it.name}" />
-            <f:textbox name="labels" value="${it.label}" />
+            <f:textbox name="label" value="${it.label}" />
         </div>
     </f:entry>
 </j:jelly>


### PR DESCRIPTION
This change fixes [JENKINS-38635](https://issues.jenkins-ci.org/browse/JENKINS-38635) "NodeLabelParameter empty on rebuild of job initiated by Startup Trigger"

I've been unable to find any use cases that are broken by it.