### PR TITLE
Ensure inherited parameters are added to new builds

### DIFF
--- a/src/main/java/com/sonyericsson/rebuild/RebuildAction.java
+++ b/src/main/java/com/sonyericsson/rebuild/RebuildAction.java
@@ -57,9 +57,6 @@ import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
-import com.sonyericsson.rebuild.RebuildParameterPage;
-import com.sonyericsson.rebuild.RebuildParameterProvider;
-
 /**
  * Rebuild RootAction implementation class. This class will basically reschedule
  * the build with existing parameters.
@@ -294,6 +291,18 @@ public class RebuildAction implements Action {
                     if (parameterValue != null) {
                         values.add(parameterValue);
                     }
+                }
+            }
+            for (ParameterValue source : paramAction.getParameters()) {
+                boolean alreadyAdded = false;
+                for (ParameterValue dest : values) {
+                    if (source.getName().equals(dest.getName())) {
+                        alreadyAdded = true;
+                        break;
+                    }
+                }
+                if (!alreadyAdded) {
+                    values.add(source);
                 }
             }
 

--- a/src/main/java/com/sonyericsson/rebuild/RebuildAction.java
+++ b/src/main/java/com/sonyericsson/rebuild/RebuildAction.java
@@ -362,11 +362,11 @@ public class RebuildAction implements Action {
                 && project.isBuildable()
                 && project instanceof Queue.Task
                 && !isMatrixRun() 
-                && !isRebuildDisbaled();
+                && !isRebuildDisabled();
 
     }
 
-    private boolean isRebuildDisbaled() {
+    private boolean isRebuildDisabled() {
         RebuildSettings settings = (RebuildSettings)getProject().getProperty(RebuildSettings.class);
         
         if (settings != null && settings.getRebuildDisabled()) {


### PR DESCRIPTION
This PR ensures that also inherited parameters are added to the retriggered builds. I.e. parameters passed from the Parameterized Trigger Plugin.

We have been running this in production for over 1.5 years.

@hagzag: No commits have been merged to master for over 2 years. Let me know if you have time to look at this PR. If not, let me know if it is NOT OK to go ahead and merge this by myself.