### PR TITLE
Fixed ClassCastException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,9 +8,13 @@
         <artifactId>plugin</artifactId>
         <!-- Since rebuild plugin is using some functions available in
         Jenkins version 1.405 ,version is updating from 1.400 to 1.405-->
-        <version>1.481</version>
-        <relativePath>../pom.xml</relativePath>
+        <version>3.2</version>
+        <relativePath />
     </parent>
+    <properties>
+        <jenkins.version>1.642.3</jenkins.version>
+        <java.level>7</java.level>
+    </properties>
     <groupId>com.sonyericsson.hudson.plugins.rebuild</groupId>
     <artifactId>rebuild</artifactId>
     <version>1.28-SNAPSHOT</version>
@@ -136,6 +140,11 @@
             <artifactId>guava</artifactId>
             <version>12.0-rc1</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>matrix-project</artifactId>
+            <version>1.12</version>
         </dependency>
     </dependencies>
     <scm>

--- a/src/main/java/com/sonyericsson/rebuild/RebuildAction.java
+++ b/src/main/java/com/sonyericsson/rebuild/RebuildAction.java
@@ -51,6 +51,7 @@ import hudson.model.PasswordParameterValue;
 import hudson.model.RunParameterValue;
 import hudson.model.StringParameterValue;
 import net.sf.json.JSONArray;
+import net.sf.json.JSONNull;
 import net.sf.json.JSONObject;
 
 import org.kohsuke.stapler.Stapler;
@@ -285,6 +286,9 @@ public class RebuildAction implements Action {
             if (!formData.isEmpty()) {
                 JSONArray a = JSONArray.fromObject(formData.get("parameter"));
                 for (Object o : a) {
+                    if (o instanceof JSONNull) {
+                        continue;
+                    }
                     JSONObject jo = (JSONObject)o;
                     String name = jo.getString("name");
                     ParameterValue parameterValue = getParameterValue(paramDefProp, name, paramAction, req, jo);


### PR DESCRIPTION
Hi, after updating Jenkins from 2.32 to 2.89 and most of the plugins, Rebuild started throwing
```
java.lang.ClassCastException: net.sf.json.JSONNull cannot be cast to net.sf.json.JSONObject
	at com.sonyericsson.rebuild.RebuildAction.doConfigSubmit(RebuildAction.java:288)
        ...
```
This fix does solve the issue.