### PR TITLE
Fix wrong usage of CauseAction, rename some method.

### DIFF
--- a/src/main/java/com/sonyericsson/rebuild/RebuildAction.java
+++ b/src/main/java/com/sonyericsson/rebuild/RebuildAction.java
@@ -226,7 +226,6 @@ public class RebuildAction implements Action {
         if (project == null) {
             return;
         }
-        System.out.println("rbx: " + (currentBuild == build));
         project.checkPermission(Item.BUILD);
         if (isRebuildAvailable()) {
 


### PR DESCRIPTION
SInce hudson.model.Run 
<pre>
 public @Nonnull List<Cause> getCauses() {
        CauseAction a = getAction(CauseAction.class);
        if (a==null)    return Collections.emptyList();
        return Collections.unmodifiableList(a.getCauses());
   }
</pre>
use just one CauseAction object to get several causes, So adding several CauseAction doesn't work.
