### PR TITLE
Update plugin POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,17 +1,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <url>http://wiki.jenkins-ci.org/display/JENKINS/Rebuild+Plugin</url>
+    <url>https://wiki.jenkins.io/display/JENKINS/Rebuild+Plugin</url>
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <!-- Since rebuild plugin is using some functions available in
-        Jenkins version 1.405 ,version is updating from 1.400 to 1.405-->
-        <version>3.2</version>
+        <version>3.48</version>
         <relativePath />
     </parent>
     <properties>
-        <jenkins.version>2.32.2</jenkins.version>
-        <java.level>7</java.level>
+        <jenkins.version>2.60.3</jenkins.version>
+        <java.level>8</java.level>
         <findbugs.failOnError>false</findbugs.failOnError>
     </properties>
     <groupId>com.sonyericsson.hudson.plugins.rebuild</groupId>
@@ -22,13 +20,13 @@
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
     </repositories>
     <licenses>
         <license>
             <name>MIT</name>
-            <url>http://www.opensource.org/licenses/mit-license.php</url>
+            <url>https://www.opensource.org/licenses/mit-license.php</url>
             <comments>Copyright 2010 Sony Ericsson Mobile Communications. All rights reserved.</comments>
         </license>
     </licenses>
@@ -46,7 +44,7 @@
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
     <build>
@@ -147,9 +145,9 @@
         </dependency>
     </dependencies>
     <scm>
-        <connection>scm:git:ssh://github.com/jenkinsci/rebuild-plugin.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/jenkinsci/rebuild-plugin.git</developerConnection>
-        <url>http://github.com/jenkinsci/rebuild-plugin</url>
+        <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+        <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
+        <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
       <tag>HEAD</tag>
   </scm>
 </project>


### PR DESCRIPTION
Bump the plugin parent POM from 3.2 to 3.48. See [the changelog](https://github.com/jenkinsci/plugin-pom/blob/master/CHANGELOG.md) and the full diff in [the compare view](https://github.com/jenkinsci/plugin-pom/compare/plugin-3.2...plugin-3.48).

While I was here, I modernized the plugin by updating to Java 8 and Jenkins core 2.60.3 or later. Java 7 support is likely to be dropped from newer versions of the plugin POM soon, so this move future-proofs this plugin for further POM updates.

I also updated the SCM Git URLs to the newer format, which allows this plugin to be tested by the Plugin Compatibility Tester (PCT).