### PR TITLE
[JENKINS-64341] Removed the tbody and table tags for new Jenkins vers…

### DIFF
--- a/src/main/resources/com/sonyericsson/rebuild/RebuildAction/parameterized.jelly
+++ b/src/main/resources/com/sonyericsson/rebuild/RebuildAction/parameterized.jelly
@@ -27,23 +27,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:local="local">
-    <d:taglib uri="local">
-        <d:tag name="blockWrapperTBody">
-            <j:choose>
-                <j:when test="${divBasedFormLayout}">
-                    <div>
-                        <d:invokeBody/>
-                    </div>
-                </j:when>
-                <j:otherwise>
-                    <tbody>
-                        <d:invokeBody/>
-                    </tbody>
-                </j:otherwise>
-            </j:choose>
-        </d:tag>
-    </d:taglib>
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
     <l:layout title="${%Rebuild}" norefresh="true" permission="${it.requiredPermission}">
         <l:side-panel>
             <l:tasks>
@@ -84,32 +68,30 @@ THE SOFTWARE.
                 <!-- Displaying the form based on current job parameter config with previous build values. -->
                 <j:forEach var="parameterDefinition"
                            items="${parametersProperty.parameterDefinitions}">
-                    <local:blockWrapperTBody>
-                        <j:set var="parameterValue"
-                               value="${paramAction.getParameter(parameterDefinition.name)}"/>
-                        <j:if test="${parameterValue != null}">
-                            <j:set var="page"
-                                   value="${it.getRebuildParameterPage(parameterValue)}"/>
-                            <j:if test="${page != null}">
-                                <j:scope>
-                                    <st:include it="${parameterValue}"
-                                                class="${page.clazz}" page="${page.page}"/>
-                                </j:scope>
-                            </j:if>
-                            <j:if test="${page == null}">
-                                <!-- Let's fallback on the regular valuePage implementation -->
-                                <st:include
-                                        it="${parameterDefinition.copyWithDefaultValue(parameterValue)}"
-                                        page="${parameterDefinition.descriptor.valuePage}"/>
-                            </j:if>
+                    <j:set var="parameterValue"
+                           value="${paramAction.getParameter(parameterDefinition.name)}"/>
+                    <j:if test="${parameterValue != null}">
+                        <j:set var="page"
+                               value="${it.getRebuildParameterPage(parameterValue)}"/>
+                        <j:if test="${page != null}">
+                            <j:scope>
+                                <st:include it="${parameterValue}"
+                                            class="${page.clazz}" page="${page.page}"/>
+                            </j:scope>
                         </j:if>
-                        <j:if test="${parameterValue == null}">
-                            <!-- No previous value in case of new property definition introduced in the config,
-                                 so let's use the default from parameter definition -->
-                            <st:include it="${parameterDefinition}"
-                                        page="${parameterDefinition.descriptor.valuePage}"/>
+                        <j:if test="${page == null}">
+                            <!-- Let's fallback on the regular valuePage implementation -->
+                            <st:include
+                                    it="${parameterDefinition.copyWithDefaultValue(parameterValue)}"
+                                    page="${parameterDefinition.descriptor.valuePage}"/>
                         </j:if>
-                    </local:blockWrapperTBody>
+                    </j:if>
+                    <j:if test="${parameterValue == null}">
+                        <!-- No previous value in case of new property definition introduced in the config,
+                             so let's use the default from parameter definition -->
+                        <st:include it="${parameterDefinition}"
+                                    page="${parameterDefinition.descriptor.valuePage}"/>
+                    </j:if>
                 </j:forEach>
                 <j:if test="${empty(parametersProperty.parameterDefinitions)}">
                     <j:forEach var="parameterValue" items="${paramAction.parameters}">

--- a/src/main/resources/com/sonyericsson/rebuild/RebuildAction/parameterized.jelly
+++ b/src/main/resources/com/sonyericsson/rebuild/RebuildAction/parameterized.jelly
@@ -27,7 +27,23 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:local="local">
+    <d:taglib uri="local">
+        <d:tag name="blockWrapperTBody">
+            <j:choose>
+                <j:when test="${divBasedFormLayout}">
+                    <div>
+                        <d:invokeBody/>
+                    </div>
+                </j:when>
+                <j:otherwise>
+                    <tbody>
+                        <d:invokeBody/>
+                    </tbody>
+                </j:otherwise>
+            </j:choose>
+        </d:tag>
+    </d:taglib>
     <l:layout title="${%Rebuild}" norefresh="true" permission="${it.requiredPermission}">
         <l:side-panel>
             <l:tasks>
@@ -68,7 +84,7 @@ THE SOFTWARE.
                 <!-- Displaying the form based on current job parameter config with previous build values. -->
                 <j:forEach var="parameterDefinition"
                            items="${parametersProperty.parameterDefinitions}">
-                    <tbody>
+                    <local:blockWrapperTBody>
                         <j:set var="parameterValue"
                                value="${paramAction.getParameter(parameterDefinition.name)}"/>
                         <j:if test="${parameterValue != null}">
@@ -93,7 +109,7 @@ THE SOFTWARE.
                             <st:include it="${parameterDefinition}"
                                         page="${parameterDefinition.descriptor.valuePage}"/>
                         </j:if>
-                    </tbody>
+                    </local:blockWrapperTBody>
                 </j:forEach>
                 <j:if test="${empty(parametersProperty.parameterDefinitions)}">
                     <j:forEach var="parameterValue" items="${paramAction.parameters}">

--- a/src/main/resources/com/sonyericsson/rebuild/RebuildDescriptor/config.jelly
+++ b/src/main/resources/com/sonyericsson/rebuild/RebuildDescriptor/config.jelly
@@ -2,15 +2,32 @@
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson"
-         xmlns:f="/lib/form">
+         xmlns:f="/lib/form"
+         xmlns:local="local">
+    <d:taglib uri="local">
+        <d:tag name="blockWrapperTable">
+            <j:choose>
+                <j:when test="${divBasedFormLayout}">
+                    <div>
+                        <d:invokeBody/>
+                    </div>
+                </j:when>
+                <j:otherwise>
+                    <table width="100%">
+                        <d:invokeBody/>
+                    </table>
+                </j:otherwise>
+            </j:choose>
+        </d:tag>
+    </d:taglib>
     <f:section title="Rebuild">
         <f:entry title="Rebuild Configuration">
-            <table width="100%">
+            <local:blockWrapperTable>
                 <f:entry title="Remember Password Enabled" field="rememberPasswordEnabled">
                     <f:checkbox
                             checked="${descriptor.rebuildConfiguration.rememberPasswordEnabled}"/>
                 </f:entry>
-            </table>
+            </local:blockWrapperTable>
         </f:entry>
     </f:section>
 </j:jelly>


### PR DESCRIPTION
[JENKINS-64341]

I checked the master version running from a Jenkins 2.279 and I was not able to reproduce the same error described in https://issues.jenkins.io/browse/JENKINS-64341. However, I removed all `table/tbody/tr/td/th tag` matches for new Jenkins versions where we have the variable `divBasedFormLayout`.