### PR TITLE
Add RebuildDispatcher extension point to allow other plugins to propagate action

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     </properties>
     <groupId>com.sonyericsson.hudson.plugins.rebuild</groupId>
     <artifactId>rebuild</artifactId>
-    <version>1.40</version>
+    <version>1.33-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Rebuilder</name>
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     </properties>
     <groupId>com.sonyericsson.hudson.plugins.rebuild</groupId>
     <artifactId>rebuild</artifactId>
-    <version>1.33-SNAPSHOT</version>
+    <version>1.40</version>
     <packaging>hpi</packaging>
     <name>Rebuilder</name>
     <repositories>

--- a/src/main/java/com/sonyericsson/rebuild/RebuildAction.java
+++ b/src/main/java/com/sonyericsson/rebuild/RebuildAction.java
@@ -24,7 +24,6 @@
  */
 package com.sonyericsson.rebuild;
 
-import com.google.common.collect.Sets;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.model.Action;
@@ -33,6 +32,7 @@ import javax.servlet.ServletException;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -347,7 +347,7 @@ public class RebuildAction implements Action {
      * @param actions the list to append additional copied actions
      */
     private void copyRebuildDispatcherActions(Run<?, ?> fromBuild, List<Action> actions) {
-        Set<Action> propagatingActions = Sets.newHashSet();
+        Set<Action> propagatingActions = new HashSet<>();
 
         // Get all RebuildActionsDispatchers that implement our extension point
         ExtensionList<RebuildActionDispatcher> rebuildActionDispatchers = RebuildActionDispatcher.all();

--- a/src/main/java/com/sonyericsson/rebuild/RebuildActionDispatcher.java
+++ b/src/main/java/com/sonyericsson/rebuild/RebuildActionDispatcher.java
@@ -1,0 +1,29 @@
+package com.sonyericsson.rebuild;
+
+import hudson.ExtensionList;
+import hudson.ExtensionPoint;
+import hudson.model.Action;
+import hudson.model.Run;
+import jenkins.model.Jenkins;
+
+import java.util.Collection;
+
+/**
+ * Extension point to propagate additional actions to the rebuild.
+ */
+public abstract class RebuildActionDispatcher implements ExtensionPoint {
+
+    /**
+     * @return the actions to include in the rebuild.
+     */
+    public abstract Collection<Action> getPropagatingActions(Run r);
+
+    /**
+     * All registered {@link RebuildActionDispatcher}s.
+     * TODO: use ExtensionList.lookup() once the Jenkins dependency is upgraded >= 1.572
+     */
+    public static ExtensionList<RebuildActionDispatcher> all() {
+        Jenkins j = Jenkins.getInstance();
+        return j == null ? ExtensionList.create((Jenkins) null, RebuildActionDispatcher.class) : j.getExtensionList(RebuildActionDispatcher.class);
+    }
+}

--- a/src/test/java/com/sonyericsson/rebuild/RebuildValidatorTest.java
+++ b/src/test/java/com/sonyericsson/rebuild/RebuildValidatorTest.java
@@ -40,6 +40,7 @@ import hudson.model.FreeStyleProject;
 import hudson.model.ParametersAction;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Project;
+import hudson.model.Run;
 import hudson.model.StringParameterDefinition;
 import hudson.model.StringParameterValue;
 
@@ -54,6 +55,8 @@ import org.jvnet.hudson.test.JenkinsRule.WebClient;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
 /**
@@ -477,6 +480,68 @@ public class RebuildValidatorTest {
                 page.asText().contains("This is a mark for test"));
     }
 
+    public void testRebuildDispatcherExtensionActionIsCopied() throws Exception {
+        FreeStyleProject project = j.createFreeStyleProject();
+        project.addProperty(new ParametersDefinitionProperty(
+                new StringParameterDefinition("name", "defaultValue")));
+
+        // Build (#1)
+        project.scheduleBuild2(0, new Cause.RemoteCause("host", "note"),
+                new ParametersAction(new StringParameterValue("name", "test")),
+                new RebuildDispatcherTestAction(true))
+                .get();
+        HtmlPage rebuildConfigPage = j.createWebClient().getPage(project,
+                "1/rebuild");
+        // Rebuild (#2)
+        j.submit(rebuildConfigPage.getFormByName("config"));
+
+        j.createWebClient().getPage(project).getAnchorByText("Rebuild Last")
+                .click();
+
+        while (project.isBuilding()) {
+            Thread.sleep(DELAY);
+        }
+        List<Action> actions = project.getLastCompletedBuild().getActions();
+        boolean hasRebuildDispatcherTestAction = false;
+        for (Action action : actions) {
+            if (action instanceof RebuildDispatcherTestAction) {
+                hasRebuildDispatcherTestAction = true;
+            }
+        }
+        assertTrue("Build should have rebuildDispatcherTestAction", hasRebuildDispatcherTestAction);
+    }
+
+    public void testRebuildDispatcherExtensionActionIsNotCopied() throws Exception {
+        FreeStyleProject project = j.createFreeStyleProject();
+        project.addProperty(new ParametersDefinitionProperty(
+                new StringParameterDefinition("name", "defaultValue")));
+
+        // Build (#1)
+        project.scheduleBuild2(0, new Cause.RemoteCause("host", "note"),
+                new ParametersAction(new StringParameterValue("name", "test")),
+                new RebuildDispatcherTestAction(false))
+                .get();
+        HtmlPage rebuildConfigPage = j.createWebClient().getPage(project,
+                "1/rebuild");
+        // Rebuild (#2)
+        j.submit(rebuildConfigPage.getFormByName("config"));
+
+        j.createWebClient().getPage(project).getAnchorByText("Rebuild Last")
+                .click();
+
+        while (project.isBuilding()) {
+            Thread.sleep(DELAY);
+        }
+        List<Action> actions = project.getLastCompletedBuild().getActions();
+        boolean hasRebuildDispatcherTestAction = false;
+        for (Action action : actions) {
+            if (action instanceof RebuildDispatcherTestAction) {
+                hasRebuildDispatcherTestAction = true;
+            }
+        }
+        assertFalse("Build should not have rebuildDispatcherTestAction", hasRebuildDispatcherTestAction);
+    }
+
     /**
      * A parameter value rebuild plugin does not know.
      */
@@ -579,6 +644,47 @@ public class RebuildValidatorTest {
                 return null;
             }
             return new RebuildParameterPage(SupportedUnknownParameterValue.class, "rebuild.groovy");
+        }
+    }
+
+    public static class RebuildDispatcherTestAction implements Action {
+        public final boolean shouldBeCopied;
+
+        public RebuildDispatcherTestAction(boolean shouldBeCopied) {
+            this.shouldBeCopied = shouldBeCopied;
+        }
+
+        @Override
+        public String getIconFileName() {
+            return null;
+        }
+        @Override
+        public String getDisplayName() {
+            return null;
+        }
+        @Override
+        public String getUrlName() {
+            return null;
+        }
+    }
+
+    @Extension
+    public static class RebuildActionDispatcherTestImpl extends RebuildActionDispatcher {
+        @Override
+        public Set<Action> getPropagatingActions(Run r) {
+            Set<Action> dispatcherActions = Sets.newHashSet();
+
+            for (Action action : r.getActions()) {
+                if (RebuildDispatcherTestAction.class.isInstance(action)) {
+                    RebuildDispatcherTestAction testAction = (RebuildDispatcherTestAction) action;
+
+                    if (testAction.shouldBeCopied) {
+                        dispatcherActions.add(action);
+                    }
+                }
+            }
+
+            return dispatcherActions;
         }
     }
 }

--- a/src/test/java/com/sonyericsson/rebuild/RebuildValidatorTest.java
+++ b/src/test/java/com/sonyericsson/rebuild/RebuildValidatorTest.java
@@ -55,6 +55,7 @@ import org.jvnet.hudson.test.JenkinsRule.WebClient;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -501,9 +502,8 @@ public class RebuildValidatorTest {
         while (project.isBuilding()) {
             Thread.sleep(DELAY);
         }
-        List<Action> actions = project.getLastCompletedBuild().getActions();
         boolean hasRebuildDispatcherTestAction = false;
-        for (Action action : actions) {
+        for (Action action : project.getLastCompletedBuild().getAllActions()) {
             if (action instanceof RebuildDispatcherTestAction) {
                 hasRebuildDispatcherTestAction = true;
             }
@@ -532,9 +532,9 @@ public class RebuildValidatorTest {
         while (project.isBuilding()) {
             Thread.sleep(DELAY);
         }
-        List<Action> actions = project.getLastCompletedBuild().getActions();
+
         boolean hasRebuildDispatcherTestAction = false;
-        for (Action action : actions) {
+        for (Action action : project.getLastCompletedBuild().getAllActions()) {
             if (action instanceof RebuildDispatcherTestAction) {
                 hasRebuildDispatcherTestAction = true;
             }
@@ -672,9 +672,9 @@ public class RebuildValidatorTest {
     public static class RebuildActionDispatcherTestImpl extends RebuildActionDispatcher {
         @Override
         public Set<Action> getPropagatingActions(Run r) {
-            Set<Action> dispatcherActions = Sets.newHashSet();
+            Set<Action> dispatcherActions = new HashSet<>();
 
-            for (Action action : r.getActions()) {
+            for (Action action : r.getAllActions()) {
                 if (RebuildDispatcherTestAction.class.isInstance(action)) {
                     RebuildDispatcherTestAction testAction = (RebuildDispatcherTestAction) action;
 


### PR DESCRIPTION
This PR is an updated version of PR #44 rebased to latest + fixed for latest changes.

It adds RebuildDispatcher extension point to allow other plugins to propagate action to the rebuild.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Unit test output:
```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running InjectedTest
[INFO] Tests run: 22, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 11.902 s - in InjectedTest
[INFO] Running com.sonyericsson.rebuild.RebuildValidatorTest
[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 54.337 s - in com.sonyericsson.rebuild.RebuildValidatorTest
[INFO]
