### PR TITLE
chore: Prepare for sunset icon removal from core

### DIFF
--- a/src/main/java/com/sonyericsson/rebuild/RebuildAction.java
+++ b/src/main/java/com/sonyericsson/rebuild/RebuildAction.java
@@ -169,7 +169,7 @@ public class RebuildAction implements Action {
     @Override
     public String getIconFileName() {
         if (isRebuildAvailable()) {
-            return "clock.gif";
+            return "clock.png";
         } else {
             return null;
         }

--- a/src/main/resources/com/sonyericsson/rebuild/RebuildAction/parameterized.jelly
+++ b/src/main/resources/com/sonyericsson/rebuild/RebuildAction/parameterized.jelly
@@ -26,12 +26,11 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:f="/lib/form">
     <l:layout title="${%Rebuild}" norefresh="true" permission="${it.requiredPermission}">
         <l:side-panel>
             <l:tasks>
-                <l:task icon="images/24x24/up.gif" href="${rootURL}/"
+                <l:task icon="icon-up icon-md" href="${rootURL}/"
                         title="${%Back to Dashboard}"/>
             </l:tasks>
         </l:side-panel>


### PR DESCRIPTION
Preparation for core sunsetting dated icons: `https://github.com/jenkinsci/jenkins/pull/5778`

@GLundh Would be nice if you can also trigger a release after merging this PR. The core PR is blocked until then.
Thanks in advance!

I couldn't find a user matching `GLundh` (`gustafl` is who's listed) in the RPU, but I assume you are the right one to pull PRs 👀 