### PR TITLE
Made it possible to select autorebuild from api request

### DIFF
--- a/src/main/java/com/sonyericsson/rebuild/RebuildAction.java
+++ b/src/main/java/com/sonyericsson/rebuild/RebuildAction.java
@@ -207,7 +207,8 @@ public class RebuildAction implements Action {
             ParametersAction paramAction = currentBuild.getAction(ParametersAction.class);
             if (paramAction != null) {
                 RebuildSettings settings = (RebuildSettings)getProject().getProperty(RebuildSettings.class);
-                if (settings != null && settings.getAutoRebuild()) {
+                if (settings != null && settings.getAutoRebuild() ||
+                        request.getParameter("autorebuild") != null) {
                     parameterizedRebuild(currentBuild, response);
                 } else {
                     response.sendRedirect(PARAMETERIZED_URL);

--- a/src/test/java/com/sonyericsson/rebuild/RebuildValidatorTest.java
+++ b/src/test/java/com/sonyericsson/rebuild/RebuildValidatorTest.java
@@ -215,6 +215,35 @@ public class RebuildValidatorTest {
 
     /**
      * Creates a new freestyle project and builds the project with a string
+     * parameter. If the build is successful, a rebuild of the last build is
+     * done, with autorebuild. The rebuild should have the same parameter values
+     * as the original build.
+     *
+     * @throws Exception
+     *             Exception
+     */
+    @Test
+    public void testAutoRebuildAsRequestParameter()
+            throws Exception {
+        FreeStyleProject project = j.createFreeStyleProject();
+        project.addProperty(new ParametersDefinitionProperty(
+                new StringParameterDefinition("name", "defaultValue")));
+
+        // Build (#1)
+        project.scheduleBuild2(0, new Cause.UserIdCause(),
+                new ParametersAction(new StringParameterValue("name", "ABC")))
+                .get();
+        HtmlPage rebuildConfigPage = j.createWebClient().getPage(project,
+                "1/rebuild?autorebuild");
+        Run r = project.getBuild("2");
+        assertNotNull(r);
+        ParametersAction paramAction = r.getAction(ParametersAction.class);
+        assertNotNull(paramAction);
+        assertEquals("ABC", paramAction.getParameter("name").getValue());
+    }
+
+    /**
+     * Creates a new freestyle project and builds the project with a string
      * parameter. If the build is succesful, a rebuild of the last build is
      * done. The rebuild on the project level should point to the last build
      *


### PR DESCRIPTION
Autorebuild, i.e. rebuilding with same parameters as the
original build, is possible to set for the project in general,
to always autorebuild.
This pull request makes it possible to choose as a request parameter, e.g:

myjob/5/rebuild?autorebuild



- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
