### PR TITLE
Handle case where last completed build does not have RebuildAction

### DIFF
--- a/src/main/java/com/sonyericsson/rebuild/RebuildLastCompletedBuildAction.java
+++ b/src/main/java/com/sonyericsson/rebuild/RebuildLastCompletedBuildAction.java
@@ -55,6 +55,9 @@ public class RebuildLastCompletedBuildAction extends AbstractRebuildAction {
             final Run<?, ?> lastCompletedBuild = project.getLastCompletedBuild();
             if (lastCompletedBuild != null) {
                 final RebuildAction action = lastCompletedBuild.getAction(RebuildAction.class);
+                if (action == null) {
+                    return null;
+                }
                 // TODO This will have unexpected results if the job configuration changed between link rendering
                 //  and when the user clicks. Seems preferable to rebuilding a "wrong" build (finished since link was
                 //  rendered though).


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This fixes a NPE introduced in #155. We've run into this issue while attempting to view job config history with the latest version, and have pinned to the previous version to avoid it.

### Testing done

I attempted to create a tests with mockito that covered the logic of `RebuildLastCompletedBuildAction#getUrlName()`, but ran into issues with `Jenkins.instance` missing. Since the change here is straightforward, I wasn't sure it warranted creating `JenkinsRule` tests.

<details>
<summary><code>RebuildLastCompletedBuildActionTest.java</code></summary>

<pre>
package com.sonyericsson.rebuild;

import hudson.model.AbstractProject;
import hudson.model.FreeStyleBuild;
import hudson.model.FreeStyleProject;
import org.junit.Before;
import org.junit.Test;
import org.junit.runner.RunWith;
import org.mockito.Mock;
import org.mockito.junit.MockitoJUnitRunner;

import static org.junit.Assert.assertEquals;
import static org.junit.Assert.assertNull;
import static org.mockito.BDDMockito.given;

@RunWith(MockitoJUnitRunner.class)
public class RebuildLastCompletedBuildActionTest {
    @Mock
    private AbstractProject<FreeStyleProject, FreeStyleBuild> project;
    @Mock
    private FreeStyleBuild lastCompletedBuild;
    @Mock
    private RebuildAction rebuildAction;
    private RebuildLastCompletedBuildAction action;

    @Before
    public void setUp() {
        action = new RebuildLastCompletedBuildAction(project);
    }

    @Test
    public void shouldReturnNullIfNotBuildable() {
        given(project.isBuildable()).willReturn(false);
        String actual = action.getUrlName();
        assertNull(actual);
    }

    @Test
    public void shouldReturnNullIfNoLastCompletedBuild() {
        given(project.isBuildable()).willReturn(true);
        given(project.getLastCompletedBuild()).willReturn(null);
        String actual = action.getUrlName();
        assertNull(actual);
    }

    @Test
    public void shouldReturnNullIfNoRebuildActionOnLastCompletedBuild() {
        given(project.isBuildable()).willReturn(true);
        given(project.getLastCompletedBuild()).willReturn(lastCompletedBuild);
        given(lastCompletedBuild.getAction(RebuildAction.class)).willReturn(null);
        String actual = action.getUrlName();
        assertNull(actual);
    }

    @Test
    public void shouldReturnUrlName() {
        given(project.isBuildable()).willReturn(true);
        given(project.getLastCompletedBuild()).willReturn(lastCompletedBuild);
        given(rebuildAction.getUrlName()).willReturn("expected-task-url");
        given(lastCompletedBuild.getAction(RebuildAction.class)).willReturn(rebuildAction);
        String expected = "lastCompletedBuild/expected-task-url";
        String actual = action.getUrlName();
        assertEquals(expected, actual);
    }
}
</pre>
</details>

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
