### PR TITLE
Improved rebuild parameter page

### DIFF
--- a/src/main/java/com/sonyericsson/rebuild/RebuildAction.java
+++ b/src/main/java/com/sonyericsson/rebuild/RebuildAction.java
@@ -414,18 +414,38 @@ public class RebuildAction extends AbstractRebuildAction implements RunAction2 {
             }
         }
 
-        // Check if we have a branched Jelly in the plugin.
-        if (getClass().getResource(String.format("/%s/%s.jelly", getClass().getCanonicalName().replace('.', '/'), value.getClass().getSimpleName())) != null) {
-            // No provider available, use an existing view provided by rebuild plugin.
+        return findRebuildParameterPage(value.getClass());
+    }
+
+    /**
+     * Recursively searches for a corresponding Jelly resource file (e.g., *.jelly) in the current
+     * plugin for the specified class or its superclasses.
+     *
+     * @param valueClass the class of the parameter value for which to search a corresponding Jelly file.
+     *                   This can be the class itself or any of its superclasses.
+     * @return {@code null} if the Jelly resource for the parameter value class,
+     *  including all its superclasses, cannot be found, it will return null, which may trigger a Jelly fallback.
+     *  <pre>
+     *  fallback: {@link ParameterDefinition#copyWithDefaultValue(ParameterValue)}
+     *  </pre>
+     */
+    private RebuildParameterPage findRebuildParameterPage(Class<?> valueClass) {
+        if (valueClass == null) {
+            return null;
+        }
+
+        String resourcePath = String.format("/%s/%s.jelly",
+                getClass().getCanonicalName().replace('.', '/'),
+                valueClass.getSimpleName());
+
+        if (getClass().getResource(resourcePath) != null) {
             return new RebuildParameterPage(
                     getClass(),
-                    String.format("%s.jelly", value.getClass().getSimpleName())
-                    );
-
+                    String.format("%s.jelly", valueClass.getSimpleName())
+            );
         }
-        // Else we return that we haven't found anything.
-        // So Jelly fallback could occur.
-        return null;
+
+        return findRebuildParameterPage(valueClass.getSuperclass());
     }
 
     @Override

--- a/src/test/java/com/sonyericsson/rebuild/RebuildActionTest.java
+++ b/src/test/java/com/sonyericsson/rebuild/RebuildActionTest.java
@@ -1,0 +1,85 @@
+package com.sonyericsson.rebuild;
+
+import hudson.model.BooleanParameterValue;
+import hudson.model.Build;
+import hudson.model.Cause;
+import hudson.model.ParameterValue;
+import hudson.model.ParametersAction;
+import hudson.model.Project;
+import hudson.model.StringParameterValue;
+import hudson.model.TextParameterValue;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Enclosed.class)
+public class RebuildActionTest {
+
+    @RunWith(Parameterized.class)
+    public static class RebuildActionRebuildParameterPageTest {
+        @Rule
+        public JenkinsRule j = new JenkinsRule();
+        private Project projectA;
+        private Build buildA;
+        private RebuildAction rebuildAction;
+
+        private ParameterValue parameterValue;
+        private String expectedJellyResourceName;
+
+        public RebuildActionRebuildParameterPageTest(ParameterValue parameterValue, String expectedJellyResourceName) {
+            this.parameterValue = parameterValue;
+            this.expectedJellyResourceName = expectedJellyResourceName;
+        }
+
+        @Before
+        public void setUp() throws IOException, ExecutionException, InterruptedException {
+            projectA = j.createFreeStyleProject("testFreeStyleA");
+            buildA = (Build) projectA.scheduleBuild2(
+                    0,
+                    new Cause.UserIdCause(),
+                    new ParametersAction()).get();
+            rebuildAction = buildA.getAction(RebuildAction.class);
+        }
+
+        @Test
+        public void getRebuildParameterPage() {
+            RebuildParameterPage parameterPage = rebuildAction.getRebuildParameterPage(parameterValue);
+            assertEquals(expectedJellyResourceName, Optional.ofNullable(parameterPage).map(RebuildParameterPage::getPage).orElse(null));
+        }
+
+        @Parameterized.Parameters
+        public static Collection<Object[]> getTestParameters() {
+            return Arrays.asList(new Object[][]{
+                    {new StringParameterValue("stringParam", "stringParam"), "StringParameterValue.jelly"},
+                    {new BooleanParameterValue("booleanParam", true), "BooleanParameterValue.jelly"},
+                    {new TextParameterValue("textParam", "textParam"), "TextParameterValue.jelly"},
+                    {new NotExistsJellyParameterValue("notExistsJellyParam"), null},
+                    {new ExistsJellySubParameterValue("existsJellySubParam", "existsJellySubParam"), "StringParameterValue.jelly"}
+            });
+        }
+
+        private static class NotExistsJellyParameterValue extends ParameterValue {
+            public NotExistsJellyParameterValue(String name) {
+                super(name);
+            }
+        }
+
+        private static class ExistsJellySubParameterValue extends StringParameterValue {
+            public ExistsJellySubParameterValue(String name, String value) {
+                super(name, value);
+            }
+        }
+    }
+}

--- a/src/test/java/com/sonyericsson/rebuild/RebuildValidatorTest.java
+++ b/src/test/java/com/sonyericsson/rebuild/RebuildValidatorTest.java
@@ -23,6 +23,8 @@
  */
 package com.sonyericsson.rebuild;
 
+import hudson.model.SimpleParameterDefinition;
+import net.sf.json.JSONObject;
 import org.htmlunit.HttpMethod;
 import org.htmlunit.WebAssert;
 import org.htmlunit.WebRequest;
@@ -61,6 +63,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestExtension;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -77,7 +80,7 @@ public class RebuildValidatorTest {
      * Sleep delay value.
      */
     public static final int DELAY = 100;
-    
+
     @Rule
     public JenkinsRule j = new JenkinsRule();
 
@@ -582,16 +585,22 @@ public class RebuildValidatorTest {
      * A parameter value rebuild plugin does not know.
      */
     public static class UnsupportedUnknownParameterValue extends
-            StringParameterValue {
+            ParameterValue {
         private static final long serialVersionUID = 3182218854913929L;
+        private String value;
 
         public UnsupportedUnknownParameterValue(String name, String value) {
             super(name, value);
         }
+
+        @Override
+        public String getValue() {
+            return value;
+        }
     }
 
     public static class UnsupportedUnknownParameterDefinition extends
-            StringParameterDefinition {
+            SimpleParameterDefinition {
         private static final long serialVersionUID = 1014662680565914672L;
 
         @DataBoundConstructor
@@ -606,9 +615,9 @@ public class RebuildValidatorTest {
         }
 
         @Override
-        public StringParameterValue getDefaultParameterValue() {
+        public ParameterValue createValue(StaplerRequest req, JSONObject jo) {
             return new UnsupportedUnknownParameterValue(this.getName(),
-                    this.getDefaultValue());
+                    jo.getString("value"));
         }
 
         @Extension


### PR DESCRIPTION
The parameter value of parameter pages jelly resource can also find the parameter value's class, including its self class and superclasses.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
