### PR TITLE
fix rebuild action for new experimental app bar api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
         <jenkins.baseline>2.555</jenkins.baseline>
         <jenkins.version>2.556</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
+        <useBeta>true</useBeta>
     </properties>
     <groupId>com.sonyericsson.hudson.plugins.rebuild</groupId>
     <artifactId>rebuild</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,14 +5,14 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>5.28</version>
+        <version>6.2189.v695a_c41f5249</version>
         <relativePath />
     </parent>
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-        <jenkins.baseline>2.479</jenkins.baseline>
-        <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+        <jenkins.baseline>2.555</jenkins.baseline>
+        <jenkins.version>2.556</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
     <groupId>com.sonyericsson.hudson.plugins.rebuild</groupId>
@@ -100,7 +100,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>3893.v213a_42768d35</version>
+                <version>6667.v64d86185fd17</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/src/main/java/com/sonyericsson/rebuild/AbstractRebuildAction.java
+++ b/src/main/java/com/sonyericsson/rebuild/AbstractRebuildAction.java
@@ -7,6 +7,8 @@ import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.Queue;
 import hudson.model.Run;
+import jenkins.model.menu.event.Event;
+import jenkins.model.menu.event.LinkEvent;
 
 public abstract class AbstractRebuildAction implements Action {
 
@@ -45,6 +47,15 @@ public abstract class AbstractRebuildAction implements Action {
     private boolean isRebuildDisabled() {
         RebuildSettings settings = getProject().getProperty(RebuildSettings.class);
         return settings != null && settings.getRebuildDisabled();
+    }
+
+    @Override
+    public Event getEvent() {
+        LinkEvent.LinkEventType eventType = LinkEvent.LinkEventType.GET;
+        if (isRequiresPOST()) {
+            eventType = LinkEvent.LinkEventType.POST;
+        }
+        return LinkEvent.of(getTaskUrl(), eventType);
     }
 
     /**


### PR DESCRIPTION
when the new app bar api is enabled the action.jelly is not considered. Implement the getEvent method in the action that returns a LinkEvent with either post of get.

Tested interactively that all scenarios work as before for freestyle
- Job without parameters: rebuild from job page and rebuild from run with new UIs disabled
- Job without parameters: rebuild from job page with new Job UI enabled
- Job without parameters: rebuild from build page with new build UI enabled
- Job with parameters: rebuild from job page and rebuild from run with new UIs disabled
- Job with parameters: rebuild from job page with new Job UI enabled
- Job with parameters: rebuild from build page with new build UI enabled

Same for pipeline (though pipeline jobs don't offer a rebuild last, only on the build page the rebuild is available and works with new and old ui with and without parameters).

fixes https://github.com/jenkinsci/jenkins/issues/26695

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
